### PR TITLE
Turn off safe_serialization from save_split so that save_function is called

### DIFF
--- a/src/transformers_neuronx/module.py
+++ b/src/transformers_neuronx/module.py
@@ -25,7 +25,7 @@ from transformers import AutoConfig
 warnings.filterwarnings("ignore", category=UserWarning, module='torch.nn.modules.lazy')
 
 def save_pretrained_split(model, save_directory):
-    model.save_pretrained(save_directory, save_function=save_split, max_shard_size='10000GB')
+    model.save_pretrained(save_directory, save_function=save_split, max_shard_size='10000GB', safe_serialization=False)
 
 
 _KEY_TO_FILENAME_JSON = 'key_to_filename.json'


### PR DESCRIPTION
Initial fix for #55 - so that save_split can work again.

Transformer v4.35.0 broke the save_split and this change will have the same function as transformer v4.34.1