### PR TITLE
Incorrect splitting of axes to retain sharding of tensors

### DIFF
--- a/src/transformers_neuronx/hlo.py
+++ b/src/transformers_neuronx/hlo.py
@@ -1254,8 +1254,7 @@ def all_reduce_sum(tensor, tp_degree, dtype=None, replica_groups=None):
         dtype=all_reduce_dtype
     )
 
-
-def _all_to_all(tensor, split_dim, concat_dim, tp_degree):
+def _all_to_all_old(tensor, split_dim, concat_dim, tp_degree):
     # Add extra reshape (and potentially transpose) before and after all-to-all CC, due to
     # 1) hlo_to_mlir_hlo would assume split_dim == concat_dim
     # 2) split_count is taken from first replica_group
@@ -1294,6 +1293,55 @@ def _all_to_all(tensor, split_dim, concat_dim, tp_degree):
         tensor = transpose(tensor, 0, 1)
     return tensor
 
+def _all_to_all(tensor, split_dim, concat_dim, tp_degree):
+    # Add extra reshape (and potentially transpose) before and after all-to-all CC, due to
+    # 1) hlo_to_mlir_hlo would assume split_dim == concat_dim
+    # 2) split_count is taken from first replica_group
+    # 3) we can only split/concat outer most dimension
+    shape = list(tensor.sizes)
+    dtype = tensor.dtype
+    assert (split_dim == 0 and concat_dim == 1) or (split_dim == 1 and concat_dim == 0), \
+        f"invalid input dimensions: split_dim={split_dim}, concat_dim={concat_dim}"
+    assert shape[split_dim] >= tp_degree and shape[split_dim] % tp_degree == 0, \
+        f"invalid split size ({shape[split_dim]}) and tp_degree ({tp_degree})"
+    shape_flat = shape[1:].copy()
+    shape_flat[0] *= shape[0]
+
+    # Assume input_shape = [N,M]
+    # split_dim == 0 and concat_dim == 1, new shape = [M*tp_degree, N/tp_degree]
+    # concat_dim == 0 and split_dim == 1, new shape = [M/tp_degree, N*tp_degree]
+    shape_new = shape.copy()
+    shape_new[split_dim] = shape_new[split_dim] // tp_degree
+    shape_new[concat_dim] *= tp_degree
+
+    # split it into tp_degree groupings and then switch dimensions 0 and 1
+    if split_dim == 1:
+        assert concat_dim == 0
+        target_shape = [shape[concat_dim], tp_degree, shape_new[split_dim]]
+        target_shape.extend(shape_new[split_dim+1:])
+        target_shape = tuple(target_shape)
+        tensor = reshape(tensor, target_shape)
+        tensor = transpose(tensor, 0, 1)
+    tensor = reshape(tensor, shape_flat)
+    tensor = dtype[shape_flat].AllToAll(
+        tensor,
+        dimensions=[0],
+        replica_groups=[list(range(tp_degree))],
+    )
+    if split_dim == 1:
+        assert concat_dim == 0
+        tensor = reshape(tensor, shape_new)
+
+    # split it into tp_degree groupings and then switch dimensions 0 and 1
+    if split_dim == 0:
+        assert concat_dim == 1
+        target_shape = [tp_degree, shape_new[split_dim], shape[concat_dim]]
+        target_shape.extend(shape_new[concat_dim+1:])
+        target_shape = tuple(target_shape)
+        tensor = reshape(tensor, target_shape)
+        tensor = transpose(tensor, 0, 1)
+        tensor = reshape(tensor, shape_new)
+    return tensor
 
 def all_to_all(tensor, split_dim, concat_dim, tp_degree):
     # Handle the case when split_dim==0 and concat_dim=0

--- a/src/transformers_neuronx/layers/attention.py
+++ b/src/transformers_neuronx/layers/attention.py
@@ -24,7 +24,7 @@ from transformers_neuronx.layers import attention, attention_utils
 from transformers_neuronx.nki.compile import nki_call
 from transformers_neuronx.hlo import quantize_kv_cache_direct_cast
 import logging
-
+from transformers_neuronx import global_debugger
 
 def query_key_value(
     hidden,
@@ -142,14 +142,44 @@ def query_key_value(
         active_q_sizes = n_active_tokens, n_seqs_per_nc, n_kv_heads * n_repeats, d_head
         active_kv_sizes = n_active_tokens, n_seqs_per_nc, n_kv_heads, d_head
 
+        # old reshape, n_seqs_per_nc is the sharding dimension
+        # however, when concatenated along the 2nd dimension
+        # the resulting tensor is different to baseline
+        # even though the shape is the same
+        # active_q_sizes = n_active_tokens, n_seqs_per_nc, n_kv_heads * n_repeats, d_head
+        # active_kv_sizes = n_active_tokens, n_seqs_per_nc, n_kv_heads, d_head
+        
+        # new reshape, n_seqs_per_nc is the sharding dimension
+        # now, n_seqs_per_nc is the 1st dimension
+        # concatenation along 1st dimension still makes them same as baseline
+        # after reshape add transpose so that the sharding dimension is the 2nd one
+        # the reason is because we want the position of the sharding dimension
+        # to be the same as KV cache (batch dimension is 2nd dimension)
+        active_q_sizes = n_seqs_per_nc, n_active_tokens, n_kv_heads * n_repeats, d_head
+        active_kv_sizes = n_seqs_per_nc, n_active_tokens, n_kv_heads, d_head
+        
         # split along batch dimension, and concat along head dimension
-        active_q = hlo.all_to_all(active_q, split_dim=0, concat_dim=1, tp_degree=tp_degree)
-        active_k = hlo.all_to_all(active_k, split_dim=0, concat_dim=1, tp_degree=tp_degree)
-        active_v = hlo.all_to_all(active_v, split_dim=0, concat_dim=1, tp_degree=tp_degree)
+        if tp_degree > 1:
+            active_q = hlo.all_to_all(active_q, split_dim=0, concat_dim=1, tp_degree=tp_degree)
+            active_k = hlo.all_to_all(active_k, split_dim=0, concat_dim=1, tp_degree=tp_degree)
+            active_v = hlo.all_to_all(active_v, split_dim=0, concat_dim=1, tp_degree=tp_degree)
 
+        # active_q = hlo.reshape(active_q, active_q_sizes)
+        # if active_q.instruction.name == "reshape.71" or active_q.instruction.name == "reshape.56":
+        #     global_debugger.tap(active_q.instruction.name, active_q, 1)
+        # active_k = hlo.reshape(active_k, active_kv_sizes)
+        # active_v = hlo.reshape(active_v, active_kv_sizes)
+        
         active_q = hlo.reshape(active_q, active_q_sizes)
+        active_q = hlo.transpose(active_q, 0, 1)
+        # if active_q.instruction.name == "transpose.57" or active_q.instruction.name == "transpose.72":
+        #     global_debugger.tap(active_q.instruction.name, active_q, 1)
+                
         active_k = hlo.reshape(active_k, active_kv_sizes)
+        active_k = hlo.transpose(active_k, 0, 1)
+        
         active_v = hlo.reshape(active_v, active_kv_sizes)
+        active_v = hlo.transpose(active_v, 0, 1)
     else:
         # shard over head
         active_q_sizes = n_active_tokens, n_seqs, n_heads_tp, d_head
@@ -691,7 +721,7 @@ def context(past_scores, active_score, past_values, active_values,
     active_output_dot = hlo.dot_general(active_prob, active_values, dimension_numbers=dot_dims)
     output = hlo.add(output_dot, active_output_dot)
 
-    if shard_over_batch:
+    if shard_over_batch and tp_degree > 1:
         # concat along batch dimension and split along head dimension
         output = hlo.all_to_all(output, split_dim=1, concat_dim=0, tp_degree=tp_degree)
         denom = hlo.all_to_all(denom, split_dim=1, concat_dim=0, tp_degree=tp_degree)
@@ -778,7 +808,8 @@ def context_combined(score, values, sparse_mask=None, n_kv_heads=0, dtype=None, 
             result = hlo.reshape(result, result_sizes)
 
             # concat along batch dimension and split along head dimension
-            result = hlo.all_to_all(result, split_dim=1, concat_dim=0, tp_degree=tp_degree)
+            if tp_degree > 1:
+                result = hlo.all_to_all(result, split_dim=1, concat_dim=0, tp_degree=tp_degree)
         else:
             result_sizes = n_seqs, n_heads_tp, n_active_tokens, d_head
             result = hlo.reshape(result, result_sizes)

--- a/src/transformers_neuronx/testing/llama_demo.py
+++ b/src/transformers_neuronx/testing/llama_demo.py
@@ -1,0 +1,184 @@
+import argparse
+import itertools
+import math
+import time
+import json
+import os
+import torch
+from transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+from transformers_neuronx import dtypes
+from transformers_neuronx.module import save_pretrained_split
+from transformers_neuronx.config import NeuronConfig, QuantizationConfig
+from transformers_neuronx.sparse_attn_utils import SparseAttnConfig, BlkSparseAttnConfig, SlidingWindowAttnConfig
+from transformers_neuronx import global_debugger
+import requests, re
+from transformers import LlamaConfig
+
+def demo(model_name, model_cls, amp_callback):
+    parser = argparse.ArgumentParser()
+    amp_choices = ['f32', 'f16', 'bf16']
+    floatx_floaty_combinations = list(itertools.product(amp_choices, amp_choices))
+    for floatx, floaty in floatx_floaty_combinations:
+        amp_choices.append(f'{floatx}-u8-{floaty}')
+    parser.add_argument('--amp', default='f32', choices=amp_choices)
+    parser.add_argument('--model_name', default=None, help="Model name for loading a pretrained model")
+    subparsers = parser.add_subparsers()
+    save_name = 'save'
+    save_parser = subparsers.add_parser(save_name)
+    save_parser.set_defaults(which=save_name)
+    save_parser.add_argument('save', help="Directory to save the model")
+    save_parser.add_argument('--random', action='store_true', help="Random weights flag. If true, config.json would be used to generate a model with random weight")
+    save_parser.add_argument('--config', type=str, default='', help="Path to config.json file (example: path/to/config.json)")
+    run_name = 'run'
+    run_parser = subparsers.add_parser(run_name)
+    run_parser.set_defaults(which=run_name)
+    run_parser.add_argument('load')
+    run_parser.add_argument('--batch_size', type=int, default=4, help="Input batch size")
+    run_parser.add_argument('--n_positions', type=int, default=128, help="Input sequence length")
+    run_parser.add_argument('--tp_degree', type=int, default=2, help="Number of neuron cores used for tensor parallel")
+    run_parser.add_argument('--unroll', type=int, default=None)
+    run_parser.add_argument('--print_latency', action='store_true', help="Print latency for generation of each output token")
+    run_parser.add_argument('--quantize', action='store_true', help="Quantize model")
+    # Sparse attention configs
+    run_parser.add_argument('--sparse_attn', type=str, choices=[None, 'blk_sparse', 'custom', 'window'],
+                            default=None, help="Use sparse attention or not. ")
+    # Block-sparse configs
+    run_parser.add_argument('--blk_size', type=int, default=128, help="Block size in blk-sparse attention")
+    run_parser.add_argument('--num_global_blks', type=int, default=0, help="Number of global blocks in blk-sparse attention")
+    run_parser.add_argument('--num_local_blks', type=int, default=1, help="Number of local blocks in blk-sparse attention")
+    run_parser.add_argument('--num_random_blks', type=int, default=0, help="Number of random blocks in blk-sparse attention")
+    # Window attention configs
+    run_parser.add_argument('--window_size', type=int, default=128, help="Window size for sliding-window attention. ")
+    run_parser.add_argument('--context_length_estimate', type=int, default=None, help="Context length estimate.")
+    run_parser.add_argument('--fuse_qkv', action='store_true')
+    run_parser.add_argument('--attention_layout', type=str, default='HSB')
+    run_parser.add_argument('--collectives_layout', type=str, default='HSB')
+    run_parser.add_argument('--cache_layout', type=str, default='SBH')
+    run_parser.add_argument('--shard_over_sequence', action='store_true')
+    run_parser.add_argument('--gqa', type=str, default=None)
+    run_parser.add_argument('--sequence_parallel_norm', action='store_true')
+    run_parser.add_argument('--debug', action='store_true')
+    run_parser.add_argument('--padding_side', type=str, default='left')
+    # TODO: args for custom sparse attention not added
+
+    args = parser.parse_args()
+    if args.model_name is not None:
+        model_name = args.model_name
+    if args.which == save_name:
+        save(args, model_name, amp_callback, model_cls)
+    elif args.which == run_name:
+        run(args, model_name, model_cls)
+
+
+def save(args, model_name, amp_callback, model_cls):
+    if args.random:
+        config = load_config(args)
+        config = LlamaConfig(**config)
+        model = AutoModelForCausalLM.from_config(config=config)
+    else:
+        model = AutoModelForCausalLM.from_pretrained(model_name, low_cpu_mem_usage=True)
+    if args.amp != 'f32':
+        dtype = dtypes.to_torch_dtype(args.amp)
+        amp_callback(model, dtype)
+    save_pretrained_split(model, args.save)
+
+
+def run(args, model_name, model_cls):
+    from pprint import pprint
+    print("run args: ")
+    pprint(vars(args))
+    torch.manual_seed(15213)
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    prompt_text = "Hello, I'm a language model,"
+    print(f'running {model_cls.__name__}.from_pretrained')
+    neuron_config = None
+    quant_config = QuantizationConfig(dequant_dtype=args.amp) if args.quantize else None
+    sparse_config = None
+    if args.sparse_attn:
+        if args.sparse_attn == "blk_sparse":
+            sparse_attn_config = BlkSparseAttnConfig(
+                blk_size=args.blk_size,
+                num_global_blks=args.num_global_blks,
+                num_local_blks=args.num_local_blks,
+                num_random_blks=args.num_random_blks
+            )
+        elif args.sparse_attn == "window":
+            sparse_attn_config = SlidingWindowAttnConfig(window_size=args.window_size)
+        else:
+            raise NotImplementedError("Interface for other attention patterns not implemented yet!")
+        sparse_config = SparseAttnConfig(
+            attn_type=args.sparse_attn, causal=True, sparse_attn_config=sparse_attn_config,
+            same_mask_per_layer=True)
+    if (args.quantize or args.sparse_attn or args.fuse_qkv or args.attention_layout or args.shard_over_sequence
+        or args.gqa or args.sequence_parallel_norm or args.collectives_layout or args.cache_layout) :
+        neuron_config = NeuronConfig(quant=quant_config, sparse_attn=sparse_config, fuse_qkv=args.fuse_qkv,
+                                     attention_layout=args.attention_layout, shard_over_sequence=args.shard_over_sequence,
+                                     group_query_attention=args.gqa, sequence_parallel_norm=args.sequence_parallel_norm,
+                                     collectives_layout=args.collectives_layout, cache_layout=args.cache_layout)
+    if args.context_length_estimate:
+        model = model_cls.from_pretrained(args.load, batch_size=args.batch_size, amp=args.amp,
+                                      tp_degree=args.tp_degree, n_positions=args.n_positions,
+                                      unroll=args.unroll, neuron_config=neuron_config,
+                                      context_length_estimate=args.context_length_estimate)
+    else:
+        model = model_cls.from_pretrained(args.load, batch_size=args.batch_size, amp=args.amp,
+                                      tp_degree=args.tp_degree, n_positions=args.n_positions,
+                                      unroll=args.unroll, neuron_config=neuron_config)
+    if args.print_latency:
+        latency_printer = LatencyPrinter()
+        model.register_forward_pre_hook(latency_printer.pre_hook)
+        model.register_forward_hook(latency_printer.hook)
+    if hasattr(model, 'register_to_neuron_hook'):
+        model.register_to_neuron_hook(lambda idx: print(f'done to_neuron layer {idx}'))
+    print('running model.to_neuron')
+    model.to_neuron()
+    with torch.inference_mode():
+        # prompt = re.sub('<[^<]+?>', '', requests.get("https://arxiv.org/html/2402.19427v1").text) # strip html tags
+        # prompt += "\n\n========================THE END======================\n"
+        # prompt += "A 10 point summary of the paper in simple words: "
+        # # put in prompt format https://llama.meta.com/docs/model-cards-and-prompt-formats/llama3_1/#prompt-format
+        # prompt = f"<|begin_of_text|><|start_header_id|>user<|end_header_id|> {prompt} <|eot_id|><|start_header_id|>assistant<|end_header_id|>"
+
+        # input_ids = tokenizer.encode(prompt, return_tensors="pt") 
+        # num_input_tokens = len(input_ids[0]) # over 26k tokens
+        # print(f"num_input_tokens: {num_input_tokens}")
+        encoded_text = tokenizer.encode(prompt_text)
+        input_ids = torch.as_tensor([encoded_text])
+        input_ids = torch.cat([input_ids for _ in range(args.batch_size)], dim=0)
+        print('running model.sample')
+        if args.debug:
+            with global_debugger.debug_context():
+                debug_tensors = global_debugger.debug_tensors
+                generated_sequence = model.sample(input_ids, sequence_length=args.n_positions)
+                for (tag_name, debug_tensor) in debug_tensors.items():
+                    print(tag_name)
+                    print(debug_tensor.shape)
+                    for item in debug_tensor:
+                        torch.set_printoptions(threshold=10_000)
+                        print(item)
+        else:
+            generated_sequence = model.sample(input_ids, sequence_length=args.n_positions)
+            print('generated_sequence=', generated_sequence)
+            outputs = [tokenizer.decode(gen_seq) for gen_seq in generated_sequence]
+            print(outputs)
+            logits = model.forward(input_ids, sequence_length=args.n_positions)
+            for item in logits:
+                torch.set_printoptions(threshold=100_000)
+                print(item)
+
+
+class LatencyPrinter:
+
+    def __init__(self):
+        self.start = None
+
+    def pre_hook(self, module, input):
+        if len(input) == 3:
+            _, cache_offset, _ = input
+            print(f'cache_offset: {cache_offset}')
+        self.start = time.time()
+
+    def hook(self, *args):
+        latency_ms = math.ceil((time.time() - self.start) * 1000)
+        print(f'Latency: {latency_ms} ms')

--- a/src/transformers_neuronx/testing/llama_driver.py
+++ b/src/transformers_neuronx/testing/llama_driver.py
@@ -1,0 +1,17 @@
+import os
+os.environ["XLA_FLAGS"] = " --xla_dump_to=dump"
+os.environ["NEURON_FRAMEWORK_DEBUG"] = "1"
+
+from llama_demo import demo
+from transformers_neuronx.llama.model import LlamaForSampling
+
+def amp_callback(model, dtype):
+    model.to(dtype)
+
+
+def main():
+    demo('meta-llama/Llama-3.1-8B-Instruct', LlamaForSampling, amp_callback)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In transformers-neuronx, it is crucial to ensure optimized machine learning pipelines, with frequent reshape and transpose sequences, have the same meaning (semantic equivalence) as the baseline pipeline. However, we found that there are cases where the usage of these layout transformation operators causes the tensors to not maintain the sharding specification between the baseline and distributed tensors. 

In the gqa shard-over-batch feature for the QKV calculation, we note that the reshape operator at the end of the calculation splits the axes of these matrices from 2 dimension to 4 dimensions. Symbolizing these dimensions, initially they have axes (a, b). After the splitting of axes, they become (c, d, e, f) where c, d represents the splitting of axes from a and e, f represents the splitting of axes from b. Initially, the sharding dimension is at a, and after the splitting, the sharding dimension becomes at d. 

However, when we concatenate the tensors across this sharding dimension d across multiple devices, the resulting tensors become different to the baseline. We propose to fix this issue by switching the sharding dimension from d to c to retain the sharding information. Then, we do a transpose by switching the first and second dimension.

Steps to reproduce the bug: 

1. Setup transformers-neuronx library on AWS Neuron trainium machine
2. Download the Llama-3 pretrained model from Huggingface https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/tree/main 
3. Edit the config.json in the Llama-3 folder to use 1 layer ("num_attention_heads": 4, "num_hidden_layers": 1, "num_key_value_heads": 1)
4. Run the [test script](https://github.com/kahfizulkifli/transformers-neuronx/blob/fix-reshape-sharding-dimension/src/transformers_neuronx/testing/llama_driver.py) provided in two modes: baseline and distributed with collectives layout BSH

```
# Baseline mode
python llama_driver.py run <model_path_folder> --tp_degree=1 --gqa=shard-over-batch --debug > tp_1.txt

# Distributed mode
python llama_driver.py run <model_path_folder> --tp_degree=2 --gqa=shard-over-batch --debug > tp_2.txt
```

5. Check that the results of both scripts are different to one another

Here are some generated outputs for the baseline and distributed.

Baseline:
```
reshape.56
torch.Size([64, 4, 4, 1024])
tensor([[[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]]])
```

Distributed:
```
reshape.71
torch.Size([64, 4, 4, 1024])
tensor([[[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]]])
```

This bug is related to this bug we found over here in the all-to-all operation #108 , although this splitting of axes does not have to be preceded by an all-to-all operation. After we introduce the fix, by reshaping the tensors to the correct sharding dimension, we can see that the tensors are equal to the baseline.

A problem with this fix is that the tensors become different from the old version since it is impossible to force the sharding dimension to be along the second dimension. However, it seems that initially it is intended to be split across the 2nd dimension since later the QKV matrices will be multiplied by the KV caches which are already split along the 2nd dimension from the beginning. In general, it might be impossible to support this feature due to differences in sharding dimension between the KV caches and the QKV tensors.

Baseline: 
```
transpose.57
torch.Size([64, 4, 4, 1024])
tensor([[[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]]])
```

Distributed:
```
transpose.72
torch.Size([64, 4, 4, 1024])
tensor([[[-0.0974,  0.2617,  0.2940,  ..., -0.0316,  0.1201,  0.3106],
         [ 0.0730,  0.1343,  0.0262,  ...,  0.4203, -0.0501,  0.0040],
         [-0.3880,  0.1703,  0.4177,  ...,  0.2850, -0.3323,  0.3105],
         [ 0.7463,  0.2157, -0.2138,  ...,  0.4804,  0.4542,  0.2629]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]],

        [[ 0.5616,  1.7017,  1.3909,  ..., -0.2786,  0.6289,  0.8052],
         [-0.2743,  0.9822,  0.2499,  ...,  0.9142, -0.3162,  0.1421],
         [-2.7863, -0.0689,  1.4579,  ..., -0.0177, -0.1165,  0.0734],
         [-0.6148, -0.3177,  0.5596,  ...,  1.0244,  0.9916,  0.7313]]])
```
